### PR TITLE
Replaced hardcoded db name with variable in Dairy Grafana dashboard json files

### DIFF
--- a/adt-adx-queries/Dairy_operation_with_data_history/Visualize_with_Grafana/Factory Comparison by Machine Type, Output.json
+++ b/adt-adx-queries/Dairy_operation_with_data_history/Visualize_with_Grafana/Factory Comparison by Machine Type, Output.json
@@ -9,9 +9,9 @@
       "pluginName": "Azure Data Explorer Datasource"
     },
     {
-      "name": "VAR_ADTENDPOINT",
+      "name": "VAR_DATAHISTORYDB",
       "type": "constant",
-      "label": "AdtEndpoint",
+      "label": "DataHistoryDatabase",
       "value": "",
       "description": ""
     },
@@ -19,6 +19,13 @@
       "name": "VAR_DATAHISTORYTABLE",
       "type": "constant",
       "label": "DataHistoryTable",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "VAR_ADTENDPOINT",
+      "type": "constant",
+      "label": "AdtEndpoint",
       "value": "",
       "description": ""
     }
@@ -147,7 +154,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"
@@ -277,7 +284,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"

--- a/adt-adx-queries/Dairy_operation_with_data_history/Visualize_with_Grafana/Machine View by Factory, Machine Type.json
+++ b/adt-adx-queries/Dairy_operation_with_data_history/Visualize_with_Grafana/Machine View by Factory, Machine Type.json
@@ -9,6 +9,13 @@
       "pluginName": "Azure Data Explorer Datasource"
     },
     {
+      "name": "VAR_DATAHISTORYDB",
+      "type": "constant",
+      "label": "DataHistoryDatabase",
+      "value": "",
+      "description": ""
+    },
+    {
       "name": "VAR_DATAHISTORYTABLE",
       "type": "constant",
       "label": "DataHistoryTable",
@@ -147,7 +154,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"
@@ -253,7 +260,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"
@@ -359,7 +366,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"
@@ -465,7 +472,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"

--- a/adt-adx-queries/Dairy_operation_with_data_history/Visualize_with_Grafana/Machine View by Factory, Maintenance Technician.json
+++ b/adt-adx-queries/Dairy_operation_with_data_history/Visualize_with_Grafana/Machine View by Factory, Maintenance Technician.json
@@ -9,9 +9,9 @@
       "pluginName": "Azure Data Explorer Datasource"
     },
     {
-      "name": "VAR_ADTENDPOINT",
+      "name": "VAR_DATAHISTORYDB",
       "type": "constant",
-      "label": "AdtEndpoint",
+      "label": "DataHistoryDatabase",
       "value": "",
       "description": ""
     },
@@ -19,6 +19,13 @@
       "name": "VAR_DATAHISTORYTABLE",
       "type": "constant",
       "label": "DataHistoryTable",
+      "value": "",
+      "description": ""
+    },
+    {
+      "name": "VAR_ADTENDPOINT",
+      "type": "constant",
+      "label": "AdtEndpoint",
       "value": "",
       "description": ""
     }
@@ -153,7 +160,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"
@@ -324,7 +331,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "database": "taanderson2DhDb",
+          "database": "${VAR_DATAHISTORYDB}",
           "datasource": {
             "type": "grafana-azure-data-explorer-datasource",
             "uid": "${DS_AZURE_DATA EXPLORER DATASOURCE}"


### PR DESCRIPTION
All three Grafana dashboard files of the Dairy example contained a hardcoded ADX database name, which caused an error after importing in Grafana.
The ADX database name is now a variable that needs to be provided during import.