### PR TITLE
Fix: Add missing .meta files to Hololens application

### DIFF
--- a/ISS/iss-hololens/.gitignore
+++ b/ISS/iss-hololens/.gitignore
@@ -40,3 +40,6 @@ Logs/
 *.pfx
 *.pfx.meta
 Assets/ScriptableObjects/AzureDigitalTwin/Credentials/*
+
+# Include unity meta files
+!*.meta

--- a/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/.gitignore
+++ b/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.iss-hololens.iml
+/modules.xml
+/projectSettingsUpdater.xml
+/contentModel.xml

--- a/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/encodings.xml
+++ b/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/indexLayout.xml
+++ b/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/vcs.xml
+++ b/ISS/iss-hololens/.idea/.idea.iss-hololens/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/ISS/iss-hololens/Assets/ADTPrefabs.meta
+++ b/ISS/iss-hololens/Assets/ADTPrefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25943123e7d2ccd42a750de5201b1950
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ADTPrefabs/ADTConnection.prefab.meta
+++ b/ISS/iss-hololens/Assets/ADTPrefabs/ADTConnection.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9ffca06bacfb2a348b5a5fe7b6ccadcf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ADTRestAPICredentials.asset.meta
+++ b/ISS/iss-hololens/Assets/ADTRestAPICredentials.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da4727a2b031d5447b5a407ec196f96f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5a4b38228cca09f4b9f5005e56d8dc34
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AddressableAssetSettings.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AddressableAssetSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d207885b24b6cc4db0da10399714075
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroupTemplates.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroupTemplates.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6412ef360ccdcd94ca3948d1ba6a9451
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroupTemplates/Packed Assets.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2387c0fbe74566645a20d1ef533c53a7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d2241e6afd85c644bc7d6fd59576f28
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Built In Data.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b0e2fbb18f3cb140af9dc3b21e7aa01
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4b6764217985754d9d1ba76e973cd0f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Remote Prefabs.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Remote Prefabs.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3b81205c55a5bc4d9fa5ef3e37e0ef9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d2e0b1863228994d965d6ee3c4cd7ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Built In Data_PlayerDataGroupSchema.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Built In Data_PlayerDataGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e91cdf15e7c7b740b4ebd1bf286ce95
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_BundledAssetGroupSchema.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb96ba8e942b2574cb971f63b5ce9ed8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_ContentUpdateGroupSchema.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Default Local Group_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f1b80879c3be77498b9898da3dc3d75
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Remote Prefabs_BundledAssetGroupSchema.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Remote Prefabs_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b42c131f7e790794abb6d9ac966b69ad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Remote Prefabs_ContentUpdateGroupSchema.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/AssetGroups/Schemas/Remote Prefabs_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0578e43518857784cbb68346c15efa34
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f35a7decb5e19f44184c8cb55dab2986
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptFastMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e02465fd023a6848b2a6c0b9b4bcd2b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c069f77a79f10a448a89991661cc83e1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptPackedPlayMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e63acbded191f2341b089f12cf3a5123
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptVirtualMode.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/DataBuilders/BuildScriptVirtualMode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7c1aab96ece5ab418bdc1527783d2c8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/DefaultObject.asset.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/DefaultObject.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8d341e90bdd67914e921da3cb85d3270
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/WindowsUniversal.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/WindowsUniversal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8bca862ceb2fad5439eac4ddd847a231
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/AddressableAssetsData/WindowsUniversal/addressables_content_state.bin.meta
+++ b/ISS/iss-hololens/Assets/AddressableAssetsData/WindowsUniversal/addressables_content_state.bin.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c8edf0ab62f01164b8d134bd48591bbf
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art.meta
+++ b/ISS/iss-hololens/Assets/Art.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9723a158eabdb24b860ba63322c1aee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Audio.meta
+++ b/ISS/iss-hololens/Assets/Art/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 164140526a25ded4b95653e179945d3e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Audio/Error Panel.wav.meta
+++ b/ISS/iss-hololens/Assets/Art/Audio/Error Panel.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: dfc6e7e9a31dcc5409b745480896a951
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce6ac6daac3334c4fb4d82eeaade529d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-100.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-100.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 0763bc38393c0724ea5b24c8076975c1
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-125.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-125.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: ec28c60afa541cd4bba58a35f8b1f825
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-150.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-150.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 7a50ef60e5d52c849927a1bbe749f2c0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-200.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-200.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 3e2e51d390aa0cb4182da44d11a32b28
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-400.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/LargeTile.scale-400.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 04bcf6abe9d19284f96f436dcab5a209
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-100.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-100.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 19948ca65a0bedf468d10e306d3dafa7
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-125.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-125.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 0cad25d40a90c864e9327176faccd8d5
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-150.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-150.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: d89ff7aabf462a84fb82f31ef0120825
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-200.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-200.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 2134e18b6429b5c4c8b74e5e3bcf85f7
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-400.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/SmallTile.scale-400.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 115ea99bb75b4c544ad362c3a58ed3ec
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-100.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-100.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: d2ba1ab03ee5bb34799477941256fd51
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-125.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-125.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 803ba897a3fd487438135f47af69e897
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-150.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-150.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 932e9fb4e0d153e4ca39a063c247047c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-200.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-200.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 4c1b5e87d7b5ef546a538587d09e7d92
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-400.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square150x150Logo.scale-400.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 29c297eb2b21cf54295af0f9d87449bd
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-100.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-100.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 67c26bf31eefc324588bc8a66f19ae0d
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: 1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-125.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-125.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: aafe3d41b8eb5fc469af3a8195a121b0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-150.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-150.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: cad601a19d644584591de5804893d3c4
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-200.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-200.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: a10ae478a6cc5b646bbacdc57494b7df
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-400.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.scale-400.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: d0a6d538154510148bd1c14e0d27df73
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-16.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-16.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: e983d2c110f34b84899fa5ca6266085d
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-24.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-24.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: d23d9955e0c7f33449801f04d468514f
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-256.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-256.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 0f14b5e7e8a3b984db6e8bf1775e9e89
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-32.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-32.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 2e870833c64fd6e4b94c662b812add8f
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-48.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Square44x44Logo.targetsize-48.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: f32c59872698693409b9834f3fef9467
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-100.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-100.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 3adf25337dd0c2f42ba0959f680513f2
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-125.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-125.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: c48889907b291404b99c380ad5a6fb05
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-150.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-150.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: d1fe2c1c532a4224d85b4d7e5780faa0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-200.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-200.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 00df98dfb790bd44b99853c0e73dc4ef
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-400.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Icons/Wide310x150Logo.scale-400.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: fd3369258eaaaf74db1fc20bebf0ff16
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Materials.meta
+++ b/ISS/iss-hololens/Assets/Art/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e076b86600d25d4989dd260ad856b6f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Materials/Chevron Indicator.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Materials/Chevron Indicator.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d2adc97c6b2ae94faafabdffff2a137
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Materials/Ground Position Indicator.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Materials/Ground Position Indicator.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f25ee3cb01127674abbb9d5735d73fff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Materials/Hover Cylinder.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Materials/Hover Cylinder.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f393325b5f44e3d4aa866d4c19161968
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Materials/Placement Line.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Materials/Placement Line.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4392f1fbbf3bb684ead52edff77108cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models.meta
+++ b/ISS/iss-hololens/Assets/Art/Models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 550c998aa6f372043837a81fe8877f20
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Chevron.fbx.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Chevron.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: 7df4002ac3788ba46b54fc893161dcfe
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/GIS_terrain_01.fbx.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/GIS_terrain_01.fbx.meta
@@ -1,0 +1,115 @@
+fileFormatVersion: 2
+guid: f7f61aba6fd6a87478d45db6d6b27792
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable:
+  - first:
+      74: 1827226128182048838
+    second: Take 001
+  externalObjects:
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: sides
+    second: {fileID: 2100000, guid: 54dde0d51ff59ea4ea5c3aed31a30fac, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: surface
+    second: {fileID: 2100000, guid: f053212cc8865d344b3641b88636c947, type: 2}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 1
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/HoverIndicator.fbx.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/HoverIndicator.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: 3a00eb579fe82414dac8a5f44248ed4b
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Materials.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dcfb16d01ef60914489c319e1392348b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Placeholder.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Placeholder.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b51602268b8b1ef4eb106b99aad4c631
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Side Hovered.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Side Hovered.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97b8c6c7c6d6f2d4dbb76df4098ac629
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Side.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Side.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54dde0d51ff59ea4ea5c3aed31a30fac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Surface.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Materials/Static Terrain Surface.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f053212cc8865d344b3641b88636c947
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Materials/White.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Materials/White.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0925abd337a2fd14b86e835a1c18d919
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Models/Materials/concrete.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Models/Materials/concrete.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df0623fd7bf106440804858cc456264e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Prefabs.meta
+++ b/ISS/iss-hololens/Assets/Art/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c2d535e948ef724b9d5f4a36f082d97
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Prefabs/Bing Maps Design.prefab.meta
+++ b/ISS/iss-hololens/Assets/Art/Prefabs/Bing Maps Design.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4702cd734b8046a44bfa2042255f8cdb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Prefabs/Bing Maps Operate.prefab.meta
+++ b/ISS/iss-hololens/Assets/Art/Prefabs/Bing Maps Operate.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d9084b0ef709c614bb130811e15fdaf6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Prefabs/Bing Maps.prefab.meta
+++ b/ISS/iss-hololens/Assets/Art/Prefabs/Bing Maps.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 040262564398d3f42bc2f6d0d832ebbe
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Prefabs/Chevron Indicator.prefab.meta
+++ b/ISS/iss-hololens/Assets/Art/Prefabs/Chevron Indicator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 21417e61c13a2e14087eb185473f8312
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Prefabs/Static Terrain.prefab.meta
+++ b/ISS/iss-hololens/Assets/Art/Prefabs/Static Terrain.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a58b25ae5bcacc84995b760f8d5ab97c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Prefabs/Target Position.prefab.meta
+++ b/ISS/iss-hololens/Assets/Art/Prefabs/Target Position.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2baad83ce01e1e94a9b622258094cc7a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Stars.mat.meta
+++ b/ISS/iss-hololens/Assets/Art/Stars.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbb0b95285a0d0943a6530fdaf70b5cd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Textures.meta
+++ b/ISS/iss-hololens/Assets/Art/Textures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e56024df766289419d16feb9fc7deee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Textures/BING_SAT_WM_02.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Textures/BING_SAT_WM_02.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: eec78f7407e16664c95fba7e9873b9d5
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Textures/IridescentSpectrum.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Textures/IridescentSpectrum.png.meta
@@ -1,0 +1,144 @@
+fileFormatVersion: 2
+guid: 6a6a7a4a4740dff48857dbf06acbfa1b
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 0
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 1
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Textures/SelectionGradient.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Textures/SelectionGradient.png.meta
@@ -1,0 +1,144 @@
+fileFormatVersion: 2
+guid: 20e0b07e8e2a0694abe0b6f7d46395fa
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 0
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 2
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Textures/line_dash.jpg.meta
+++ b/ISS/iss-hololens/Assets/Art/Textures/line_dash.jpg.meta
@@ -1,0 +1,132 @@
+fileFormatVersion: 2
+guid: 1e4d3d63b10840a49b99f40bbc9eab71
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 2
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Art/Textures/white8x8.png.meta
+++ b/ISS/iss-hololens/Assets/Art/Textures/white8x8.png.meta
@@ -1,0 +1,144 @@
+fileFormatVersion: 2
+guid: 283c88502f259ed44a268f0e3a4f23ca
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth.meta
+++ b/ISS/iss-hololens/Assets/Earth.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fb8a727edbd6c548a2d1135f471a16c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/EarthScene.unity.meta
+++ b/ISS/iss-hololens/Assets/Earth/EarthScene.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3523ca6db1f20c458e410e2aba84ee8
+timeCreated: 1456247099
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/EarthSceneSettings.lighting.meta
+++ b/ISS/iss-hololens/Assets/Earth/EarthSceneSettings.lighting.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9519c3d72437b3443a3298c383e48ca1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 4890085278179872738
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Editor.meta
+++ b/ISS/iss-hololens/Assets/Earth/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 399032bd9f7c88f46890d3b536a27294
+folderAsset: yes
+timeCreated: 1487177568
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Editor/EarthEditor.cs.meta
+++ b/ISS/iss-hololens/Assets/Earth/Editor/EarthEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cfd95605c4548f948b02afaf3e2d6cec
+timeCreated: 1487177571
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Editor/EarthLogo.png.meta
+++ b/ISS/iss-hololens/Assets/Earth/Editor/EarthLogo.png.meta
@@ -1,0 +1,100 @@
+fileFormatVersion: 2
+guid: 3e71bc7402f056148aa97b86bb638763
+timeCreated: 1487177610
+licenseType: Store
+TextureImporter:
+  fileIDToRecycleName: {}
+  serializedVersion: 4
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 0
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    filterMode: -1
+    aniso: 1
+    mipBias: -1
+    wrapMode: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaUsage: 0
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 2
+  textureShape: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+  - buildTarget: Standalone
+    maxTextureSize: 2048
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+  - buildTarget: Android
+    maxTextureSize: 2048
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+  - buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+  - buildTarget: WebGL
+    maxTextureSize: 2048
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Materials.meta
+++ b/ISS/iss-hololens/Assets/Earth/Materials.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 08b31b4dc8be1ae4787b4d90fe1a1764
+folderAsset: yes
+timeCreated: 1433269041
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Materials/EarthMaterial.mat.meta
+++ b/ISS/iss-hololens/Assets/Earth/Materials/EarthMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7984698def12c74fa2b3aac0d0ac5b0
+timeCreated: 1456335122
+licenseType: Store
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Materials/EarthShader.shader.meta
+++ b/ISS/iss-hololens/Assets/Earth/Materials/EarthShader.shader.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32a0ef2a7ef59ad47846655a3c02fa8d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Materials/StarfieldMaterial.mat.meta
+++ b/ISS/iss-hololens/Assets/Earth/Materials/StarfieldMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20cdb01e1d91c6746aa1497afcabb355
+timeCreated: 1456249286
+licenseType: Store
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Prefab.meta
+++ b/ISS/iss-hololens/Assets/Earth/Prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fb5f3b17d638a324f8934d85df38a743
+folderAsset: yes
+timeCreated: 1456352858
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Prefab/Earth.prefab.meta
+++ b/ISS/iss-hololens/Assets/Earth/Prefab/Earth.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2e22098ce7c8da4590cceb5113bd50e
+timeCreated: 1456352876
+licenseType: Store
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Readme.txt.meta
+++ b/ISS/iss-hololens/Assets/Earth/Readme.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5abae9422d47689429d1c2e57cd4c1e7
+timeCreated: 1456352815
+licenseType: Store
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Scripts.meta
+++ b/ISS/iss-hololens/Assets/Earth/Scripts.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: cee9e94e3b05e54439e07e9c4ebc3d09
+folderAsset: yes
+timeCreated: 1433269078
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Scripts/EarthRootScript.cs.meta
+++ b/ISS/iss-hololens/Assets/Earth/Scripts/EarthRootScript.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b6a3d7cf08b022543afc097128883b86
+timeCreated: 1487177921
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Scripts/EarthScript.cs.meta
+++ b/ISS/iss-hololens/Assets/Earth/Scripts/EarthScript.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7a70c881415690c418f87514fe62ae5f
+timeCreated: 1456247318
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Scripts/MoveScript.cs.meta
+++ b/ISS/iss-hololens/Assets/Earth/Scripts/MoveScript.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9278714cdaebb1a41a6cb538a04fc686
+timeCreated: 1456369985
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Scripts/SphereScript.cs.meta
+++ b/ISS/iss-hololens/Assets/Earth/Scripts/SphereScript.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a7503af7db833c840a891458c125d4e9
+timeCreated: 1456416322
+licenseType: Store
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Textures.meta
+++ b/ISS/iss-hololens/Assets/Earth/Textures.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bbc50bf135147104eb9bef42d60722de
+folderAsset: yes
+timeCreated: 1456349073
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Textures/EarthClouds.png.meta
+++ b/ISS/iss-hololens/Assets/Earth/Textures/EarthClouds.png.meta
@@ -1,0 +1,116 @@
+fileFormatVersion: 2
+guid: 961fa74443856d247867fce623b3d325
+TextureImporter:
+  fileIDToRecycleName: {}
+  externalObjects: {}
+  serializedVersion: 4
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 1
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: -3
+  maxTextureSize: 4096
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -1
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 2
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - buildTarget: DefaultTexturePlatform
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Standalone
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Android
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Windows Store Apps
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: WebGL
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Textures/EarthDiffuse.png.meta
+++ b/ISS/iss-hololens/Assets/Earth/Textures/EarthDiffuse.png.meta
@@ -1,0 +1,57 @@
+fileFormatVersion: 2
+guid: 7dfcb90673cf9a44281e7da0b32902b2
+timeCreated: 1457125283
+licenseType: Store
+TextureImporter:
+  fileIDToRecycleName: {}
+  serializedVersion: 2
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    linearTexture: 0
+    correctGamma: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 0
+  cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
+  seamlessCubemap: 0
+  textureFormat: -3
+  maxTextureSize: 4096
+  textureSettings:
+    filterMode: -1
+    aniso: -1
+    mipBias: -1
+    wrapMode: -1
+  nPOTScale: 1
+  lightmap: 0
+  rGBM: 0
+  compressionQuality: 50
+  allowsAlphaSplitting: 0
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaIsTransparency: 0
+  textureType: -1
+  buildTargetSettings: []
+  spriteSheet:
+    sprites: []
+    outline: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Textures/EarthLights.png.meta
+++ b/ISS/iss-hololens/Assets/Earth/Textures/EarthLights.png.meta
@@ -1,0 +1,57 @@
+fileFormatVersion: 2
+guid: 8d73a1f30b7717d4f8f40e2a2128ae7e
+timeCreated: 1457125284
+licenseType: Store
+TextureImporter:
+  fileIDToRecycleName: {}
+  serializedVersion: 2
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    linearTexture: 0
+    correctGamma: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 0
+  cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
+  seamlessCubemap: 0
+  textureFormat: -3
+  maxTextureSize: 4096
+  textureSettings:
+    filterMode: -1
+    aniso: -1
+    mipBias: -1
+    wrapMode: -1
+  nPOTScale: 1
+  lightmap: 0
+  rGBM: 0
+  compressionQuality: 50
+  allowsAlphaSplitting: 0
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaIsTransparency: 0
+  textureType: -1
+  buildTargetSettings: []
+  spriteSheet:
+    sprites: []
+    outline: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Textures/EarthNormalMap.png.meta
+++ b/ISS/iss-hololens/Assets/Earth/Textures/EarthNormalMap.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: c2fa05cb71836f246b5eabf3f3c6151c
+TextureImporter:
+  fileIDToRecycleName: {}
+  externalObjects: {}
+  serializedVersion: 4
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 0
+    linearTexture: 1
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 1
+    externalNormalMap: 1
+    heightScale: 0.2
+    normalMapFilter: 1
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: -1
+  maxTextureSize: 4096
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -1
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 1
+  textureShape: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - buildTarget: DefaultTexturePlatform
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Standalone
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Android
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Textures/EarthSpecular.png.meta
+++ b/ISS/iss-hololens/Assets/Earth/Textures/EarthSpecular.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 5ca5bf05f3cb3b046be353275c0ef45c
+TextureImporter:
+  fileIDToRecycleName: {}
+  externalObjects: {}
+  serializedVersion: 4
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 0
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: -3
+  maxTextureSize: 4096
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -1
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 2
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 10
+  textureShape: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - buildTarget: DefaultTexturePlatform
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Standalone
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - buildTarget: Android
+    maxTextureSize: 4096
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Earth/Textures/EarthStarfield.png.meta
+++ b/ISS/iss-hololens/Assets/Earth/Textures/EarthStarfield.png.meta
@@ -1,0 +1,57 @@
+fileFormatVersion: 2
+guid: 436c0fe13f07bf847a6626d843d8659c
+timeCreated: 1457125281
+licenseType: Store
+TextureImporter:
+  fileIDToRecycleName: {}
+  serializedVersion: 2
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    linearTexture: 0
+    correctGamma: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 0
+  cubemapConvolution: 0
+  cubemapConvolutionSteps: 7
+  cubemapConvolutionExponent: 1.5
+  seamlessCubemap: 0
+  textureFormat: -3
+  maxTextureSize: 4096
+  textureSettings:
+    filterMode: -1
+    aniso: -1
+    mipBias: -1
+    wrapMode: -1
+  nPOTScale: 1
+  lightmap: 0
+  rGBM: 0
+  compressionQuality: 50
+  allowsAlphaSplitting: 0
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaIsTransparency: 0
+  textureType: -1
+  buildTargetSettings: []
+  spriteSheet:
+    sprites: []
+    outline: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Gizmos.meta
+++ b/ISS/iss-hololens/Assets/Gizmos.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49f88e3ebbae32a4b9b8194842bf144d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS.meta
+++ b/ISS/iss-hololens/Assets/ISS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa17adbe42e8eaa489bfb8b5b6d106a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed43263f6bb412d499793feb33a9e3d3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_01.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_01.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 50f9fddf30c1d1a4eaba0df16ade37de
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_dark _.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_dark _.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d43ff80e245ce4b4f8de52b2765c8b2d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_dull.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_dull.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dea19a832f352d3409a01e5ac68cd889
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_n.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_n.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 036a953f19692144da3244bc75cc2ac1
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 0
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 1
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_shiny_n.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_01_shiny_n.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd0756c1f50f26745bc546cbe7823d0d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_02.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_02.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 2c2c2be02455971429b628227d2054fe
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_02_dark _.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_02_dark _.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6dee6e91b1779c1428ec5acbf5be1bff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_02_dull.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_02_dull.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92008b463ed9df2459a5658b181f5c2b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_03.png.002.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_03.png.002.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 1075073119ca9c24ea4ea87c2db6e89b
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_03.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_03.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: fbff0715cddecb7469df642d6bfc369d
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_dull.001.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_dull.001.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e19aff175a2b6d84eb58a7677b6db24a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_dull.002.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_dull.002.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9ed871a0ae160264593afa621b60eb54
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_dull.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_dull.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a2baff5ce634656469ddd5b19b924016
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_n.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_n.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 3b2978509aa2fd64685e150c3f835943
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 0
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 1
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_shiny_n.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_03_shiny_n.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e7892b64baae004e85bf84659f190cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_04.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_04.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: f3a39b8f2674ab34480e1f643880dee6
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_04_dull.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_04_dull.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d03ca36229fc4334bb18867ad1e953d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_01.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_01.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 743ab966d470bee4e97cba988c3e4a0b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_01.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_01.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 27818f3f5683889439fbe5341b698353
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_02.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_02.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8644d0ec0ef15f04bb06ad6fe67bcaf7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_02.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_02.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 8de99508a5a0a64429eea6beb81548cb
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_03.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_03.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e80c0e6cf4f83b84288cedc067f9843c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_03.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_03.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 032c96145eb13f74a9968ce23d3cc216
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_04.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_04.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0786d6c2393e3bc46a8846f8ad2af4e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_04.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_04.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 4f887e8cd51151f489ae30c1fc163796
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_05.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_05.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f72ea2854e3297a4d8220c23fb87eb9c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_05.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_05.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 0607e946c195ebb42ae75409f835caa4
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_06.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_06.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8cd6ee619a6f8fb42986e3b696c7102c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_06.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_06.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 9d2406300b4de3a4aaa4cac0a6378e9f
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_07.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_07.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 51f4306ed3229e74d9ee58cffe75f0be
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_07.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_07.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 9289886e9e4d1a947b34f189e37a2cc7
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_08.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_08.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec7767b2c83a58f47967382d7fefc1c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_08.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ISS_AO_08.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 534cbee1ca97f6f4d952267b74991c11
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #25 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #25 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 960f97ef677c771429c0d6fed86d1013
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #25.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #25.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b3ecff205a211b449c250d63b4cad79
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #26 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #26 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db6b0cbb3e64a594f930d23b78843b6a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #26.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #26.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad028746c055d29479d1d0f82b6134bf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #27 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #27 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 837acf5d8b7857a4d8b33b3c7a0ef912
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #27.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #27.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d66056c823aaae4989c1622c1dc7d5c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #28 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #28 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da16efea9f9c7c249b2425096d8185f9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #28.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #28.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb37db2f38b635c4c8b527e7d26013f6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #29 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #29 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9341e7e3cecca834d97610d10bfc6bf8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #29.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #29.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee0b470014a331a468be1354ba8dddf7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #30 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #30 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70bb71c1c0ed84d489bfcc63a45599d3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #30.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #30.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 484319d469a0f9e41a0e6d60fc90c592
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #31 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #31 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb9feb6ff91b48243835930b13c44d77
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #31.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #31.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 35c99ab411a36164a9c29b892289b18a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #32 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #32 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0bdb7c4b116e5b49a2cc4db5db4293b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #32.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #32.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 66197dd2ba6729445b11eabc9d8af3e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #33 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #33 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 559673e3f1487f14da66548d3b589f88
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #33.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #33.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2e58bfde2526d745a93177a9b3ce67c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #34 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #34 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7b2fcddbcef5c245b415b40904f233d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #34.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #34.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 758fbeafb526ff14eb4b56bd16b96eb3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #35 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #35 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb434b6cdd436e448b13de0b05f11778
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #35.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #35.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05b7658adc0dab24b934d5a0dbcec6c0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #36 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #36 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7c546840f6c53f4cbbb0308b75cb40d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/Material #36.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/Material #36.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de28610cc410f964b81f593a3c93b8ab
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/New Lighting Settings.lighting.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/New Lighting Settings.lighting.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca933d4ab1e54f247ab8fcd751c277cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 4890085278179872738
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/base_metal 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/base_metal 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68bc956088b98804bba1477e165d9fe3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/base_metal.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/base_metal.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2d1d463dde3da1c439f53f77aed85dc3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ecostress metal.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ecostress metal.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2714284448efdf54386c3566950eecf0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ecostress.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ecostress.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc7ac6016d0d74f49bdfe3c1e488ea76
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ecostress.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ecostress.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 100a3dfd2244b2b4986440be94e6ab1c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ecostressWhite 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ecostressWhite 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4ed07d84e762aa24ebe1ecfdf0fe4bd8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ecostressWhite.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ecostressWhite.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65cee266b978c184abc8bbc92d28b6b1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/ecostress_dexter.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/ecostress_dexter.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b7b85017cb3e6d4d9f9004d7a233aa8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/foil_n.png.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/foil_n.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: dc648156b692a7a42a4407fbef8bb738
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 0
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 1
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/foil_silver 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/foil_silver 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb04c1c4129bb8c4cbbc755c76baec90
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/foil_silver.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/foil_silver.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3c1df0c5a7dc7649b2a1d4935d63599
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture0.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture0.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fd4236c9b5bd3d44892da11aea134d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture10.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture10.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46ec212fdf0f29c49a5afe31eea6a6d6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture11.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture11.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c2404e15359f5048b49ed02b0351f86
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture14.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture14.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f7d041b9ac7de214fa78f8b5477d6eae
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture15.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture15.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9fc8345089bab94dbea04e4f10cd866
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture16.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture16.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a198e4aa538cc0a4abe13ec1607aad60
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture17.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture17.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9bda27ed5a6b58f4c9eb8c358403cdaa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture18.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture18.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b87dc12ee4151e4ba7facf634eb9145
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture19.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture19.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de8c0af6b9a6519409c0491d6cc06c6d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture2.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture2.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cf860df0b866cc4fb629bfcb05106ff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture21.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture21.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: adc00b1139a42db438194a38ffd4982b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture22.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture22.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7579643668cf524aa028ff9eb589dfa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture23.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture23.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd500fc75822610438d546d2873b4336
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture24.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture24.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b62c3eac435c0240b36d64b56daded4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture25.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture25.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c25388d714572284fb24cc3877d501b1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture3.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture3.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c345403cd2ca82c449e697cac2b4d7b7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture4.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture4.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c49d47aeceb79c440a6a3af605c1cc00
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture5.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture5.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6507b5ebacdf8964c8c95885c5d56437
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture6.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture6.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 91c1e55ed5dadfc4a923889a0ab6aad3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture7.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture7.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74f85cd484cee934fb7b701125aed151
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture8.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture8.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd776a85bbe41ad428f18a7cbbf53ee3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture9.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/glTF_Embedded_Texture9.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 45af40169b0a6eb498b9be05235ca59a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/olive _ 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/olive _ 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bba20955444321d4082a2eb5937bfdf4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/olive _.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/olive _.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 57eb0c280564e72488c3c97106be559a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/plastic black 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/plastic black 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0f1f0331bb7a964881505894ba1babc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/plastic black.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/plastic black.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e60ab1004ff66f4ebcc7b08d2fb1103
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/shiny_panel.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/shiny_panel.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2057edd13f6d24c4d8b249179be9e047
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/white 1.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/white 1.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f2a8d3a317e1ca347888f98716985938
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/Materials/white.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/Materials/white.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c698b0438251e27458d517c28af5d942
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/New Material.mat.meta
+++ b/ISS/iss-hololens/Assets/ISS/New Material.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f641f00ad3ad1904e881496ffcccd540
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/RotateConstant.cs.meta
+++ b/ISS/iss-hololens/Assets/ISS/RotateConstant.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4be15abe4f963af46955bf9f1cd4ca7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ISS/iss.fbx.meta
+++ b/ISS/iss-hololens/Assets/ISS/iss.fbx.meta
@@ -1,0 +1,305 @@
+fileFormatVersion: 2
+guid: 809919fea2e830a449b39c0f715a6492
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable:
+  - first:
+      74: 1827226128182048838
+    second: Take 001
+  externalObjects:
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_01_dark _
+    second: {fileID: 2100000, guid: d43ff80e245ce4b4f8de52b2765c8b2d, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_01_dull
+    second: {fileID: 2100000, guid: dea19a832f352d3409a01e5ac68cd889, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_01_shiny_n
+    second: {fileID: 2100000, guid: cd0756c1f50f26745bc546cbe7823d0d, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_02_dark _
+    second: {fileID: 2100000, guid: 6dee6e91b1779c1428ec5acbf5be1bff, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_02_dull
+    second: {fileID: 2100000, guid: 92008b463ed9df2459a5658b181f5c2b, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_03_dull
+    second: {fileID: 2100000, guid: a2baff5ce634656469ddd5b19b924016, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_03_dull.001
+    second: {fileID: 2100000, guid: e19aff175a2b6d84eb58a7677b6db24a, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_03_dull.002
+    second: {fileID: 2100000, guid: 9ed871a0ae160264593afa621b60eb54, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_03_shiny_n
+    second: {fileID: 2100000, guid: 4e7892b64baae004e85bf84659f190cc, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_04_dull
+    second: {fileID: 2100000, guid: d03ca36229fc4334bb18867ad1e953d3, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_01
+    second: {fileID: 2100000, guid: 743ab966d470bee4e97cba988c3e4a0b, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_02
+    second: {fileID: 2100000, guid: 8644d0ec0ef15f04bb06ad6fe67bcaf7, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_03
+    second: {fileID: 2100000, guid: e80c0e6cf4f83b84288cedc067f9843c, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_04
+    second: {fileID: 2100000, guid: 0786d6c2393e3bc46a8846f8ad2af4e4, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_05
+    second: {fileID: 2100000, guid: f72ea2854e3297a4d8220c23fb87eb9c, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_06
+    second: {fileID: 2100000, guid: 8cd6ee619a6f8fb42986e3b696c7102c, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_07
+    second: {fileID: 2100000, guid: 51f4306ed3229e74d9ee58cffe75f0be, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ISS_AO_08
+    second: {fileID: 2100000, guid: ec7767b2c83a58f47967382d7fefc1c9, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #25
+    second: {fileID: 2100000, guid: 960f97ef677c771429c0d6fed86d1013, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #26
+    second: {fileID: 2100000, guid: db6b0cbb3e64a594f930d23b78843b6a, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #27
+    second: {fileID: 2100000, guid: 837acf5d8b7857a4d8b33b3c7a0ef912, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #28
+    second: {fileID: 2100000, guid: da16efea9f9c7c249b2425096d8185f9, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #29
+    second: {fileID: 2100000, guid: 9341e7e3cecca834d97610d10bfc6bf8, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #30
+    second: {fileID: 2100000, guid: 70bb71c1c0ed84d489bfcc63a45599d3, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #31
+    second: {fileID: 2100000, guid: eb9feb6ff91b48243835930b13c44d77, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #32
+    second: {fileID: 2100000, guid: d0bdb7c4b116e5b49a2cc4db5db4293b, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #33
+    second: {fileID: 2100000, guid: 559673e3f1487f14da66548d3b589f88, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #34
+    second: {fileID: 2100000, guid: d7b2fcddbcef5c245b415b40904f233d, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #35
+    second: {fileID: 2100000, guid: eb434b6cdd436e448b13de0b05f11778, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: Material #36
+    second: {fileID: 2100000, guid: c7c546840f6c53f4cbbb0308b75cb40d, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: base_metal
+    second: {fileID: 2100000, guid: 68bc956088b98804bba1477e165d9fe3, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ecostress
+    second: {fileID: 2100000, guid: fc7ac6016d0d74f49bdfe3c1e488ea76, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ecostress metal
+    second: {fileID: 2100000, guid: 2714284448efdf54386c3566950eecf0, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ecostressWhite
+    second: {fileID: 2100000, guid: 4ed07d84e762aa24ebe1ecfdf0fe4bd8, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: ecostress_dexter
+    second: {fileID: 2100000, guid: 2b7b85017cb3e6d4d9f9004d7a233aa8, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: foil_silver
+    second: {fileID: 2100000, guid: fb04c1c4129bb8c4cbbc755c76baec90, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: olive _
+    second: {fileID: 2100000, guid: bba20955444321d4082a2eb5937bfdf4, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: plastic black
+    second: {fileID: 2100000, guid: d0f1f0331bb7a964881505894ba1babc, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: shiny_panel
+    second: {fileID: 2100000, guid: 2057edd13f6d24c4d8b249179be9e047, type: 2}
+  - first:
+      type: UnityEngine:Material
+      assembly: UnityEngine.CoreModule
+      name: white
+    second: {fileID: 2100000, guid: f2a8d3a317e1ca347888f98716985938, type: 2}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK.meta
+++ b/ISS/iss-hololens/Assets/MRTK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 44f980c56981ac141a349ea634e4e92d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: beb89f9c6ff411e4a8a30a63c02f9277
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/ChannelPacker.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/ChannelPacker.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 72ba6d7b37f51174bb3c7be2acc8fb0d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/DepthBufferPostProcess.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/DepthBufferPostProcess.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 8e3074f33703cbb4186e9b6c2c958fda
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/InstancedColored.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/InstancedColored.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d199a2ca60343bb49ad9a41ddb45a083
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/InvisibleShader.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/InvisibleShader.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 54ea9f30be414d86a7260eceb330c449
+timeCreated: 1510009044
+licenseType: Free
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/MRTK.Shaders.sentinel.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/MRTK.Shaders.sentinel.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 05852dd420bb9ec4cb7318bfa529d37c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/MRTK_Wireframe.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/MRTK_Wireframe.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5c1653eb4e20b76499141de7bc57c063
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/MixedRealityShaderUtils.cginc.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/MixedRealityShaderUtils.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: dfab24eea71ce3745be340d7a24fe8eb
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/MixedRealityStandard.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/MixedRealityStandard.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5bdea20278144b11916d77503ba1467a
+timeCreated: 1519154700
+licenseType: Pro
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/MixedRealityTextMeshPro.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/MixedRealityTextMeshPro.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1c504b73bf66872479cd1215fb5ce0fe
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/Shaders/Text3DShader.shader.meta
+++ b/ISS/iss-hololens/Assets/MRTK/Shaders/Text3DShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 80c006b91733f1a4991c49af89321ecd
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a9aaa267f6602444bb8dbcc5143afd5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX/BoxDisplayConfiguration.asset.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX/BoxDisplayConfiguration.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9c92a85b39dc0a14bb23f2ae2e910d14
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX/RotationHandlesConfigurationDesign.asset.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX/RotationHandlesConfigurationDesign.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2ef17323eab2e74c89c9014e6ab8c7d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX/RotationHandlesConfigurationOperate.asset.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX/RotationHandlesConfigurationOperate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46a46fc2d57d0c143b25cb605925b0d4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX/ScaleHandlesConfiguration.asset.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX/ScaleHandlesConfiguration.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fce5ba50af78164482af79aec04a7b7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX/TranslationHandlesConfiguration.asset.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX/TranslationHandlesConfiguration.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f884e9405bcc64f41a5ace272f25eaf6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX/UI RotationHandlesConfig.asset.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX/UI RotationHandlesConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9309930ee7f0e0643999fe5d9440feb4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MRTK/UX/UI ScaleHandlesConfig.asset.meta
+++ b/ISS/iss-hololens/Assets/MRTK/UX/UI ScaleHandlesConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02662833d3160524f8229304dc6ec7fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated.meta
+++ b/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0476578d80bc8b4da1f6390d981ce65
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/CustomProfiles.meta
+++ b/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/CustomProfiles.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: afcc689ec89e1b747980473a1339c24a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/CustomProfiles/BladeMRHoloLens2MRTKProfile.asset.meta
+++ b/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/CustomProfiles/BladeMRHoloLens2MRTKProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f91f20b72ee99254b87e1e71f4b854d0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/CustomProfiles/BladeMRMixedRealityCameraProfile.asset.meta
+++ b/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/CustomProfiles/BladeMRMixedRealityCameraProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 103faa7e90222a048acd4c179947099d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/MRTK.Generated.sentinel.meta
+++ b/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/MRTK.Generated.sentinel.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81620e3c0d1febe4d8ea0990d76b2649
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/ProjectPreferences.asset.meta
+++ b/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/ProjectPreferences.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 264ebeeceb88e0a44a9455f29cdc8d17
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/link.xml.meta
+++ b/ISS/iss-hololens/Assets/MixedRealityToolkit.Generated/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6758415eb8e2fb5488365f0d2a978e49
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease.meta
+++ b/ISS/iss-hololens/Assets/NonRelease.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11a2b4a147146d8488d168430de6eca5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds.meta
+++ b/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ea3c8f39def0184d888d79626a50730
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor.meta
+++ b/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 984b17badfb63cc43a91135b49252cae
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/AutoBuild.cs.meta
+++ b/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/AutoBuild.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1d1060d13ea4454fa63e4a10b3123ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/AutoBuildSettings.cs.meta
+++ b/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/AutoBuildSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f8b1499f7cb7534ba1ba7dd9adad5b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/AutoBuildSettingsData.asset.meta
+++ b/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/AutoBuildSettingsData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e09cdfe48d3a93f4fa10c2cd1237d09a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/BladeMR.Editor.asmdef.meta
+++ b/ISS/iss-hololens/Assets/NonRelease/AutomatedBuilds/Editor/BladeMR.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1e077f1972fb1c74b9816f7a38f146d1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/NonRelease/BladeMR.asmdef.meta
+++ b/ISS/iss-hololens/Assets/NonRelease/BladeMR.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d6b24a4c1bc65864faaf7547a0fd1ca9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins.meta
+++ b/ISS/iss-hololens/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8538c152d87a32645a15164fe45f7cfe
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/MessagePack.Annotations.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/MessagePack.Annotations.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: be22de5ffc6427543be781d9df5ee8bf
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/MessagePack.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/MessagePack.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 4ff68fc3d6fd821479f824b4e7d29429
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Connections.Abstractions.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Connections.Abstractions.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: e42b56aeaae20a745b0eea6bd6a2d0b1
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Http.Connections.Client.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Http.Connections.Client.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: c7ae7d63a8e4f49408df3828616eaf2a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Http.Connections.Common.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Http.Connections.Common.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 54b743b9d4d2df4428cfe84b48118c69
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Http.Features.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.Http.Features.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 24ad8a5de4f1f7c48b7f2e7984aa3389
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Client.Core.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Client.Core.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 2f4fe195e4613394c83cbdfb62fd17db
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Client.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Client.dll.meta
@@ -1,0 +1,87 @@
+fileFormatVersion: 2
+guid: 8bde787d55680c44c94adcee09c519b9
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude Lumin: 0
+        Exclude OSXUniversal: 0
+        Exclude Win: 0
+        Exclude Win64: 0
+        Exclude WindowsStoreApps: 0
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Lumin: Lumin
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 1
+      settings:
+        CPU: x86
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: AnyCPU
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Common.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Common.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 8450ddd19af60b145a61f481d761f6c7
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Protocols.Json.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Protocols.Json.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: c1131e0aa7191bf44b18dba08f538210
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: c1537d1dbbbeb9c438a97d36f00a1735
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 8032a432463fe4b4a8911a669d7cc4c6
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.Bcl.AsyncInterfaces.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.Bcl.AsyncInterfaces.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: c72cfecbdc985624082b89f38d97b060
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.DependencyInjection.Abstractions.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.DependencyInjection.Abstractions.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 8d7ee1ec163aab24ab636413b68fc04d
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.DependencyInjection.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.DependencyInjection.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 5bbfe0ed08a82674185fd02073a89004
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Logging.Abstractions.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Logging.Abstractions.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 425227ed80c0a2942892c9093f51134f
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Logging.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Logging.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 70eb38b5f9be87d4489a30fb283e6038
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Options.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Options.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 4d6381672163e76428261ff57693fc8f
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Primitives.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Microsoft.Extensions.Primitives.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: d0bf7a60c6cb60649924cc2a657fc204
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/Newtonsoft.Json.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/Newtonsoft.Json.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 48a653c4fd9c73a43aab0427f84bd363
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Buffers.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Buffers.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 4d608910fa1c26b379d6a74832634bd3
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Diagnostics.DiagnosticSource.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Diagnostics.DiagnosticSource.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 59e16ddf656001542a9e6156b39cea60
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.IO.Pipelines.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.IO.Pipelines.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 6df34edb02162874e997e27a8bf999d1
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Memory.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Memory.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 7e93bdcfa60f991db9d2cd68d46154a1
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Net.Http.Json.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Net.Http.Json.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 947eb6020478d0a41b1964d2ecaef164
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Runtime.CompilerServices.Unsafe.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 3e0047f37cdb071278cf7a6406d72647
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Text.Encodings.Web.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Text.Encodings.Web.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: ff383569b85989143afeab2e79408e95
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Text.Json.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Text.Json.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 906901c7434fde54dac059fea3f5e7cb
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Threading.Channels.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Threading.Channels.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: cd7d742ad97132c4ba8b5a0bef314026
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/System.Threading.Tasks.Extensions.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/System.Threading.Tasks.Extensions.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: 7181e8be42e14bf41909e863d5260615
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/TestLibrary.dll.meta
+++ b/ISS/iss-hololens/Assets/Plugins/TestLibrary.dll.meta
@@ -1,0 +1,33 @@
+fileFormatVersion: 2
+guid: acbcd1e32b1bd554b846d06f69628b2c
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Plugins/link.xml.meta
+++ b/ISS/iss-hololens/Assets/Plugins/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 227a7e5408b7dd640a1e1e202002e039
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scenes.meta
+++ b/ISS/iss-hololens/Assets/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62c2892b126c2c94a992f251dce1a19c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scenes/MainScene.unity.meta
+++ b/ISS/iss-hololens/Assets/Scenes/MainScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9b525369e7b672e44b91a2da80a9fa11
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 635db72cf36458147901e7be4f5edc19
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/AzureDigitalTwin.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/AzureDigitalTwin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32bd4e35a64fad246b69ef8d31b5d6f0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/AzureDigitalTwin/Credentials.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/AzureDigitalTwin/Credentials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b28b691a635a77c4e9a0480c0d8dfd9b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/BladeMR Reference.asmref.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/BladeMR Reference.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7d2cebeb0b0cefb4abec7f1ac919e18c
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7442b36906183c343b16d039c3af7bd3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnADTAuthenticated.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnADTAuthenticated.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8672be91e737f2b46aca6b73c89df43c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnADTAuthenticationFailed.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnADTAuthenticationFailed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d2e6f553b87c8c498ca5272e7284f61
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnADTDataReceived.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnADTDataReceived.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1b255e047e0c2c48b7aa0d1c565ef7c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnResetCommandSent.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnResetCommandSent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77e4111ca16eee84fb9e7b3a1057c105
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnResetScene.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnResetScene.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 51b1cdbc6a40ca74c8209f2744c3b89c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnSummonOverviewPanel.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnSummonOverviewPanel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc52c9665b304d94abba6b253567ce6c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinHoverEnd.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinHoverEnd.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a4583aaa1b3b6b049bf3418f6a02ff21
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinHoverStart.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinHoverStart.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d81f0e857e450c49a494a0fbc9c484f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinInstantiated.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinInstantiated.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 204ed458aeb57d54595976733b37f031
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinSelected.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Events/OnTwinSelected.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5198af0592966e448e9dfd2b4cfe906
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 000e2c64f84e45548bcb87b238f90063
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Range.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Range.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9abf1f8c5daf1014ab0cc1f3ee3f64c9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeAmbientTemperature.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeAmbientTemperature.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c651792d3aff1d746b14f6d8c897e2d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeAngle.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeAngle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b60e7f319886c4844b2e63e70c5fbbea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeCurrentSolar.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeCurrentSolar.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82ffd107e531f6d419b9872fae577ccc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeKursRange.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeKursRange.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f18679de9b04f594d8688f14c6263c48
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeO2Prod.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeO2Prod.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6895e7de18d6604409e60f75f66b46ac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangePowerSolar.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangePowerSolar.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ee2cdc18631637458c7b002ee1c9002
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeQuality0100.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeQuality0100.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ad3b9cfd8ea4547498704ae669e6706e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeVoltageSolar.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeVoltageSolar.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 20d9053adc0cd4b48a7a11e74c025a73
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Rangecoolingtemp.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Rangecoolingtemp.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b7a85d69bdf93348bd9e3b22551a63a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeppCo2.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeppCo2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 06988a4a02bf2974e8df305b970d3877
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeppO2.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/RangeppO2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 673f63721d9fc9a4ba3cb2971e9ccc11
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Rangeppbool.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Rangeppbool.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 964d0f389cd414b4aa2f7ecfbc5f8696
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Rangeppn2.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Telemetry Range Data/Rangeppn2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e771d845f7b4b7f428279c1d85b659ff
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a160c0f88f39114dafa4bb2a22f9a52
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/1A.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/1A.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c7068ff22a9497041b40a73e75288d8b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/1B.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/1B.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e81e0f7e4d70a5d4294016b2a9b8041c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/2A.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/2A.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c2d58c9636407a49a5c5db9282ef137
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/2B.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/2B.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 24df6a5969e20264089eed2c434979ef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/3A.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/3A.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c344e1abaa90f7a439fd5d34bdde27a0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/3B.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/3B.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 459e9decc10001c48acff91ec1e3c58c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/4A.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/4A.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b7db36d9af6cfea4193b76f710ee603c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/4B.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/4B.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 99bd055cb4681fa4f90da33fb321e973
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Harmony.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Harmony.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1dbf9593f5e2f343b356f6d50da0ab0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Site Data.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Site Data.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96cacb5954ba14f4fb31fe1099ebeae9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Tranquility.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Tranquility.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a86ec279bd6d00b4faeba88f787d6597
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Zvezda.asset.meta
+++ b/ISS/iss-hololens/Assets/ScriptableObjects/Twin Data/Zvezda.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f26290b9e0c2bd44d893d7d13532bdb6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts.meta
+++ b/ISS/iss-hololens/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f182e027ae594874bafd1589998f0386
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin.meta
+++ b/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 990c7fc60eef8e14c8f8725d9f1fa049
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/ADTRestClient.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/ADTRestClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3dcb011d53beea44a838b023414039fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/Constants.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/Constants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8523acf428acba141b41e8b5056638d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/Credentials.meta
+++ b/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/Credentials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 36465f05aa854cf49be4fb82b4919249
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/Credentials/ADTRestAPICredentialsScriptableObject.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/AzureDigitalTwin/Credentials/ADTRestAPICredentialsScriptableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f656cda89ef9634897e11007a067319
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/BladeMR Reference.asmref.meta
+++ b/ISS/iss-hololens/Assets/Scripts/BladeMR Reference.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2700c5756a524ac4db80fb203292bce3
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1893310dae411b4e86066fd4468dbd7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/ADTAuthenticationEventListener.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/ADTAuthenticationEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a53d75e895a84e140bedba3a9e52cbbe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/ADTAuthenticationGameEvent.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/ADTAuthenticationGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52cec8bac6866414faed76300a0c23b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/ADTEventListener.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/ADTEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5280afc799f8c624ab998a35fb27ab34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/ADTGameEvent.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/ADTGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7b9c596920d3374daa9bf50040c9c1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/GameEvent.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/GameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 30de971c06f958146a95d62ea8e1e403
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/GameEventListener.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/GameEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5624eba7046813349bcda5b327f8c8ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/TwinEventListener.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/TwinEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6123321e8001ab4fab77a46b9c7f144
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Events/TwinGameEvent.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Events/TwinGameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fc7f47a6d5f20048ba40a079bcd06fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/ISS.meta
+++ b/ISS/iss-hololens/Assets/Scripts/ISS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 660cebda91351a346a480c8a70023ea8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/ISS/EarthFaceLatLon.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/ISS/EarthFaceLatLon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6528eff4bf589484ebcf554d09681e1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/ISS/PinchSliderRotateTransform.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/ISS/PinchSliderRotateTransform.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1dcf9d4079e538c498769bc680a877b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/ISS/RotateSunOnTelemetry.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/ISS/RotateSunOnTelemetry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5da54322fd68d5243b6bff1f464204e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/ISS/RotationFromTelemetry.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/ISS/RotationFromTelemetry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54318507e6279fc4ca599e74a194b7db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/ISS/SolarScriptableObject.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/ISS/SolarScriptableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bc4ab2590c544b4aa072768d2923e04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/ISS/TelemetryListener.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/ISS/TelemetryListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b10b0f78ec0dd654bbdffe33bd5ef49f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/MapLoadingIndicator.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/MapLoadingIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab0ae3089101e0b4399414fa4f68581a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/SignalR.meta
+++ b/ISS/iss-hololens/Assets/Scripts/SignalR.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 50b3a3cd49d73564daf53299c1dfeac5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/SignalR/ADTDataHandler.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/SignalR/ADTDataHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 778cc16d61317ae4192d223574625121
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/SignalR/AsyncUtils.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/SignalR/AsyncUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e5aa944aef6a59428e51ebec5a44387
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/SignalR/PropertyMessage.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/SignalR/PropertyMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6c8fa1daa437b724fa2f0476575a57cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/SignalR/SignalRService.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/SignalR/SignalRService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d74efb836aa0b8c479bdadbf7569441f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/SignalR/TwinDataScriptableObjectHolder.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/SignalR/TwinDataScriptableObjectHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a207861f2c66d941b27cfd0ce8935dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/SignalR/UnityDispatcher.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/SignalR/UnityDispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a391574fb962611438432cfe59fe60ea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/TwinData.meta
+++ b/ISS/iss-hololens/Assets/Scripts/TwinData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 485f96177b1d0524c927eb0569748504
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/TwinData/SolarData.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/TwinData/SolarData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c4a12d568b473540b4d77b685466cec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/TwinData/TelemetryRangeData.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/TwinData/TelemetryRangeData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c62376b10946e644396b2fac3fdf59d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/TwinData/TwinData.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/TwinData/TwinData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 36642de1a06c04b45ae7eb89f2792397
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/TwinData/TwinDataScriptableObject.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/TwinData/TwinDataScriptableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b6ca782f7114a54da88d1b751ddaa05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/TwinData/TwinGraphData.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/TwinData/TwinGraphData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9747e10b5362b7f44b3e1da0bf87940a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/UI.meta
+++ b/ISS/iss-hololens/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5239803b3f257ab4d83e4532cb31568e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/UI/MessageBoxUI.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/UI/MessageBoxUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eabbbfd80a81f574dab52b1645c75aa1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/UI/OperateSceneUIManager.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/UI/OperateSceneUIManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fea7c82d906c0bb43baf227192a68a90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/UI/ProgressController.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/UI/ProgressController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b149898c98a8a4140b6b75f4837cced4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/UI/SiteOverviewButton.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/UI/SiteOverviewButton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 274f8220955545246bc27bde8acabda1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/UI/SiteOverviewUIPanel.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/UI/SiteOverviewUIPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6b29c5f3a7d91f4ebba22bcb97bf373
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/UI/TwinUIPanel.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/UI/TwinUIPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c10de1d074a2db34693f4c5c612cc318
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Utils.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82c0e67bffab11f4bbd8ea0b4bb250aa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Utils/AzureRemoteAssetLoader.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Utils/AzureRemoteAssetLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6609e722ec3dece4c84d528c2e374376
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Utils/HologramScale.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Utils/HologramScale.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21ab87b98c39fbb4a9851a127fca184b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Utils/HoverMaterialSwitcher.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Utils/HoverMaterialSwitcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19a69db444292af45b09188f6480281d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Utils/RotateRPM.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Utils/RotateRPM.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4d65c9f0f0c5774691a90689f8ecab8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Utils/SnapToGround.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Utils/SnapToGround.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac5d29517153ff94e9a0f9106ff50664
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Scripts/Utils/TargetPositionIndicator.cs.meta
+++ b/ISS/iss-hololens/Assets/Scripts/Utils/TargetPositionIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67ce914aeab711140a33bdff82b0974e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests.meta
+++ b/ISS/iss-hololens/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63b5b320d4a34d24c80dc0951ed0f020
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Edit Mode.meta
+++ b/ISS/iss-hololens/Assets/Tests/Edit Mode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 81aa1279aa354fe4489742979f99fe56
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Edit Mode/BladeMR.Tests.EditMode.asmdef.meta
+++ b/ISS/iss-hololens/Assets/Tests/Edit Mode/BladeMR.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d7a8099e891eea84dbac40882788c1b0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Play Mode.meta
+++ b/ISS/iss-hololens/Assets/Tests/Play Mode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43bce7966869c1541ba4e3b58dda2042
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Play Mode/AddressablesTest.cs.meta
+++ b/ISS/iss-hololens/Assets/Tests/Play Mode/AddressablesTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0fa656ed7af7dbb4e8b36534f8dcd60d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Play Mode/BladeMR.Tests.PlayMode.asmdef.meta
+++ b/ISS/iss-hololens/Assets/Tests/Play Mode/BladeMR.Tests.PlayMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 25c943b2c8e59c6428fafda38409443c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Play Mode/StaticTerrainTests.cs.meta
+++ b/ISS/iss-hololens/Assets/Tests/Play Mode/StaticTerrainTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 495d7436943b66a48b25f313e2f7effd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Test Assets.meta
+++ b/ISS/iss-hololens/Assets/Tests/Test Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2f5e5b19e8682f45ab56c020c359f2e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/Tests/Test Assets/Cube.prefab.meta
+++ b/ISS/iss-hololens/Assets/Tests/Test Assets/Cube.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c167f1656f9fcae43ab50a908a469ba0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f54d1bd14bd3ca042bd867b519fee8cc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Documentation.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Documentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e7e8f5a82a3a134e91c54efd2274ea9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Documentation/TextMesh Pro User Guide 2016.pdf.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Documentation/TextMesh Pro User Guide 2016.pdf.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1b8d251f9af63b746bf2f7ffe00ebb9b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Fonts.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Fonts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ab70aee4d56447429c680537fbf93ed
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Fonts/LiberationSans - OFL.txt.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Fonts/LiberationSans - OFL.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e59c59b81ab47f9b6ec5781fa725d2c
+timeCreated: 1484171296
+licenseType: Pro
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Fonts/LiberationSans.ttf.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Fonts/LiberationSans.ttf.meta
@@ -1,0 +1,19 @@
+fileFormatVersion: 2
+guid: e3265ab4bf004d28a9537516768c1c75
+timeCreated: 1484171297
+licenseType: Pro
+TrueTypeFontImporter:
+  serializedVersion: 2
+  fontSize: 16
+  forceTextureCase: -2
+  characterSpacing: 1
+  characterPadding: 0
+  includeFontData: 1
+  use2xBehaviour: 0
+  fontNames: []
+  fallbackFontReferences: []
+  customCharacters: 
+  fontRenderingMode: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 243e06394e614e5d99fab26083b707fa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 731f1baa9d144a9897cb1d341c2092b8
+folderAsset: yes
+timeCreated: 1442040525
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Drop Shadow.mat.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Drop Shadow.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e73a58f6e2794ae7b1b7e50b7fb811b0
+timeCreated: 1484172806
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Fallback.asset.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Fallback.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e498d1c8094910479dc3e1b768306a4
+timeCreated: 1484171803
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Outline.mat.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF - Outline.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 79459efec17a4d00a321bdcc27bbc385
+timeCreated: 1484172856
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF.asset.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Fonts & Materials/LiberationSans SDF.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f586378b4e144a9851e7b34d9b748ee
+timeCreated: 1484171803
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/LineBreaking Following Characters.txt.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/LineBreaking Following Characters.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fade42e8bc714b018fac513c043d323b
+timeCreated: 1425440388
+licenseType: Store
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/LineBreaking Leading Characters.txt.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/LineBreaking Leading Characters.txt.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d82c1b31c7e74239bff1220585707d2b
+timeCreated: 1425440388
+licenseType: Store
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Sprite Assets.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Sprite Assets.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 512a49d95c0c4332bdd98131869c23c9
+folderAsset: yes
+timeCreated: 1441876896
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Sprite Assets/EmojiOne.asset.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Sprite Assets/EmojiOne.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c41005c129ba4d66911b75229fd70b45
+timeCreated: 1480316912
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Style Sheets.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Style Sheets.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 4aecb92fff08436c8303b10eab8da368
+folderAsset: yes
+timeCreated: 1441876950
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Style Sheets/Default Style Sheet.asset.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/Style Sheets/Default Style Sheet.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f952c082cb03451daed3ee968ac6c63e
+timeCreated: 1432805430
+licenseType: Store
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Resources/TMP Settings.asset.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Resources/TMP Settings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f5b5dff67a942289a9defa416b206f3
+timeCreated: 1436653997
+licenseType: Pro
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9f693669af91aa45ad615fc681ed29f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Bitmap-Custom-Atlas.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Bitmap-Custom-Atlas.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 48bb5f55d8670e349b6e614913f9d910
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Bitmap-Mobile.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Bitmap-Mobile.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1e3b057af24249748ff873be7fafee47
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Bitmap.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Bitmap.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 128e987d567d4e2c824d754223b3f3b0
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF Overlay.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF Overlay.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: dd89cf5b9246416f84610a006f916af7
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF SSD.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF SSD.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 14eb328de4b8eb245bb7cea29e4ac00b
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile Masking.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile Masking.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bc1ede39bf3643ee8e493720e4259791
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile Overlay.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile Overlay.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a02a7d8c237544f1962732b55a9aebf1
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile SSD.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile SSD.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c8d12adcee749c344b8117cf7c7eb912
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fe393ace9b354375a9cb14cdbbc28be4
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Surface-Mobile.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Surface-Mobile.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 85187c2149c549c5b33f0cdb02836b17
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Surface.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF-Surface.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f7ada0af4f174f0694ca6a487b8f543d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_SDF.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 68e6db2ebdc24f95958faec2be5558d6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Sprite.shader.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMP_Sprite.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: cf81c85f95fe47e1a27f6ae460cf182c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro.cginc.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 407bc68d299748449bbf7f48ee690f8d
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro_Mobile.cginc.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro_Mobile.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c334973cef89a9840b0b0c507e0377ab
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro_Properties.cginc.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro_Properties.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3997e2241185407d80309a82f9148466
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro_Surface.cginc.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Shaders/TMPro_Surface.cginc.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d930090c0cd643c7b55f19a38538c162
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Sprites.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Sprites.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0603b6d5186471b96c778c3949c7ce2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Sprites/EmojiOne Attribution.txt.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Sprites/EmojiOne Attribution.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 381dcb09d5029d14897e55f98031fca5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Sprites/EmojiOne.json.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Sprites/EmojiOne.json.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f05276190cf498a8153f6cbe761d4e6
+timeCreated: 1480316860
+licenseType: Pro
+TextScriptImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/TextMesh Pro/Sprites/EmojiOne.png.meta
+++ b/ISS/iss-hololens/Assets/TextMesh Pro/Sprites/EmojiOne.png.meta
@@ -1,0 +1,431 @@
+fileFormatVersion: 2
+guid: dffef66376be4fa480fb02b19edbe903
+TextureImporter:
+  fileIDToRecycleName:
+    21300000: EmojiOne_0
+    21300002: EmojiOne_1
+    21300004: EmojiOne_2
+    21300006: EmojiOne_3
+    21300008: EmojiOne_4
+    21300010: EmojiOne_6
+    21300012: EmojiOne_7
+    21300014: EmojiOne_8
+    21300016: EmojiOne_9
+    21300018: EmojiOne_10
+    21300020: EmojiOne_11
+    21300022: EmojiOne_12
+    21300024: EmojiOne_13
+    21300026: EmojiOne_5
+    21300028: EmojiOne_14
+  externalObjects: {}
+  serializedVersion: 5
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: -1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -1
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spritePixelsToUnits: 100
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - serializedVersion: 2
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - serializedVersion: 2
+    buildTarget: Standalone
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - serializedVersion: 2
+    buildTarget: iPhone
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  - serializedVersion: 2
+    buildTarget: Android
+    maxTextureSize: 512
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: EmojiOne_0
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 384
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 4bcc36da2108f2c4ba3de5c921d25c3c
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_1
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 384
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: e9eea8093eaeaee4d901c4553f572c22
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_2
+      rect:
+        serializedVersion: 2
+        x: 256
+        y: 384
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 49451da35411dcc42a3692e39b0fde70
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_3
+      rect:
+        serializedVersion: 2
+        x: 384
+        y: 384
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f65709664b924904790c850a50ca82bc
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_4
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 256
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 5b92c568a5ec9ad4b9ed90e271f1c9a8
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_6
+      rect:
+        serializedVersion: 2
+        x: 256
+        y: 256
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: b10f2b48b7281594bb8a24a6511a35af
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_7
+      rect:
+        serializedVersion: 2
+        x: 384
+        y: 256
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 10a600f9329dc2246a897e89f4d283cd
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_8
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 128
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 66cffa363b90ab14787d8a5b90cf4502
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_9
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 128
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 55cf3d409c9b89349b1e1bdc1cc224ad
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_10
+      rect:
+        serializedVersion: 2
+        x: 256
+        y: 128
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2a9e58eaf96feef42bcefa1cf257193f
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_11
+      rect:
+        serializedVersion: 2
+        x: 384
+        y: 128
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 2489120affc155840ae6a7be2e93ce19
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_12
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 412349a150598d14da4d7140df5c0286
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_13
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 0
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a937464b42bb3634782dea34c6becb6c
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_5
+      rect:
+        serializedVersion: 2
+        x: 256
+        y: 0
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: b0f933b217682124dbfc5e6b89abe3d0
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: EmojiOne_14
+      rect:
+        serializedVersion: 2
+        x: 128
+        y: 256
+        width: 128
+        height: 128
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: f7235c763afe4434e8bb666750a41096
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 3e32d8f5477abfc43b19066e8ad5032e
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+  spritePackingTag: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ff3986ecfe071e4faee271d998f9031
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Animations.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Animations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de379f101ef380048a2dc0515af777dc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Animations/Marker.controller.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Animations/Marker.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b8cfd2351776a44f84c7ed32b82f0dc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Animations/MarkerAnim.anim.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Animations/MarkerAnim.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 614cada972cfdb24f9145b6acaf0739d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9267d953e16c0041910781568028c42
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/Backplate Hover.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/Backplate Hover.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 845721143518d0642b42fa48ad72ad40
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/Backplate.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/Backplate.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aec5d2ef4cc1dbf4e862f121c1a54afc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/BackplateDialog.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/BackplateDialog.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70c28fb14dfe5ca4eaaac4961a484c29
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/IconError.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/IconError.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7bc7225830e97104daee62063ea2699f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/IconSuccess.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/IconSuccess.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73602431aa8485243b93bc2700e5c8ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/Icon_Spinner.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/Icon_Spinner.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 415de2c6c3dc8cf42a13b0d585f2766f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/MRTK_Standard_MarkerOrange.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/MRTK_Standard_MarkerOrange.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f5a4651a0fe140544bfc669c1af87cf3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Backplate Hover.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Backplate Hover.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: add9614ef9d76c4448d83428482fe22a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Backplate Rounded.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Backplate Rounded.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e688508e4989e6e43a9e918909065918
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Backplate.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Backplate.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 73497376649ed4246bd9e4d7880a66d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Carrymode Outline.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Carrymode Outline.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c157b2c7bdfc86e46baa24c909b6694e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Hand Menu Backplate.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Hand Menu Backplate.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8832f9c471d20be48982f05d8b60d69f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Line.mat.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Materials/UI Line.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d9cc289b85dd12c4598cbfab34c36e39
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Models.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cacfc975811e5b9489efddd80986e4df
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Models/Blade_Marker.fbx.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Models/Blade_Marker.fbx.meta
@@ -1,0 +1,102 @@
+fileFormatVersion: 2
+guid: ac0aac0b7c3059844af3b02f5c62268b
+ModelImporter:
+  serializedVersion: 20200
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 2
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 100
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 1
+    importLights: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8933778030a79b45b80977de9a51f88
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Alert Indicator.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Alert Indicator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bbd8d6fb20e9e68459006c82dafa7df0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2c7dedff4c8a3fc40b87db4f79b244eb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/PanelDataVisContent.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/PanelDataVisContent.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15e61383e0635cd4b9c83317bc2bad55
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/PanelDataVisHeading.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/PanelDataVisHeading.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77c02d7f9fb37b04b927a7b22cdf2c27
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/ProgressBar.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/ProgressBar.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e05bc6837d52d014c994023fed71df62
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/ProgressBarSmall.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/ProgressBarSmall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9015274636acb774e88ffb5f30f5e871
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/ProgressCircle.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/DataVisuals/ProgressCircle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 004c8144616a0054ca1b76e4d71e18ba
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4857c692de3dc3a49bc628505e7ee45c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog/DialogError.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog/DialogError.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3753f9b0efca854e87556a8f90dbebd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog/DialogGenericMessage.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog/DialogGenericMessage.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 759a69f3dd1b81b4e95805dad0afcec7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog/DialogSuccess.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Dialog/DialogSuccess.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc782a1234382f34aacbd28fed5cbbb1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Divider.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/Divider.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4b18b970a09ed642872b862dc3dcd85
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/HandMenuOperate.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/HandMenuOperate.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6febd15c3c0e0ee4ca166746c43d5faa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/PressableButtonHoloLens2.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/PressableButtonHoloLens2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b8fda29cdb4f5be4c84ac385c2ef26c6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/TwinInfoPanel.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/TwinInfoPanel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a26b57027bc283e45ba1e5768bebb33f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/TwinOverviewButton.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/TwinOverviewButton.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 841e16009cd3e7245a614fb4b0fae351
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/TwinOverviewMenu.prefab.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Prefabs/TwinOverviewMenu.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 464864d0975377349ac9dffc44291b9b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Textures.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Textures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7abf039412ae67d43bd248d5a9721d2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Textures/IconErrorTriangle.png.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Textures/IconErrorTriangle.png.meta
@@ -1,0 +1,180 @@
+fileFormatVersion: 2
+guid: 0f3c1b8fc78aec7418f263ccce0d36a0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: tvOS
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Lumin
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Textures/IconSuccess.png.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Textures/IconSuccess.png.meta
@@ -1,0 +1,180 @@
+fileFormatVersion: 2
+guid: 1f9b095e73b9940429cc932cbe094a8e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: 12
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 1
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: tvOS
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: iPhone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Lumin
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Textures/IconWarning.png.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Textures/IconWarning.png.meta
@@ -1,0 +1,144 @@
+fileFormatVersion: 2
+guid: 2e6151611f164154ca4769c7551eddab
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Textures/Icon_Spinner.png.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Textures/Icon_Spinner.png.meta
@@ -1,0 +1,144 @@
+fileFormatVersion: 2
+guid: 8d3b7ebcff5882542a08d7bc71e12f71
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Textures/ProgressBar.png.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Textures/ProgressBar.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 4fe0a04c41dc2354d9a9432d40c61f0d
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 200
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/UIPrefabs/Textures/ProgressCircle.png.meta
+++ b/ISS/iss-hololens/Assets/UIPrefabs/Textures/ProgressCircle.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 0b547a20c7081f34d8bd34d2343e60b3
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: 1
+    wrapV: 1
+    wrapW: -1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 200
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 1
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/WSATestCertificate.pfx.meta
+++ b/ISS/iss-hololens/Assets/WSATestCertificate.pfx.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a46ce38f85f4d6a41b0762aa918baedc
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR.meta
+++ b/ISS/iss-hololens/Assets/XR.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 946374cf3bbccdd43a7139ddac25b007
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR/Loaders.meta
+++ b/ISS/iss-hololens/Assets/XR/Loaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef9946d57d87a2c48b0c2c6ba84aa9b0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR/Loaders/Open XR Loader No Pre Init.asset.meta
+++ b/ISS/iss-hololens/Assets/XR/Loaders/Open XR Loader No Pre Init.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54f27d5637b6e414d9434e0e122116e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR/Loaders/Open XR Loader.asset.meta
+++ b/ISS/iss-hololens/Assets/XR/Loaders/Open XR Loader.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60fefbe34cfa7bb49adec44761d874a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR/Settings.meta
+++ b/ISS/iss-hololens/Assets/XR/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9d801d5d75003b4f88ae3d92fe2aebb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR/Settings/Open XR Package Settings.asset.meta
+++ b/ISS/iss-hololens/Assets/XR/Settings/Open XR Package Settings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ba16014566e21274cb627786d3a825ab
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR/Settings/OpenXR Editor Settings.asset.meta
+++ b/ISS/iss-hololens/Assets/XR/Settings/OpenXR Editor Settings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: facf9cde8497c0944a55dc0b6d81d0b5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Assets/XR/XRGeneralSettings.asset.meta
+++ b/ISS/iss-hololens/Assets/XR/XRGeneralSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abff8632290b16d4a95422c2d70e39c1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ISS/iss-hololens/Library/com.unity.addressables/AddressablesBuildTEP.json
+++ b/ISS/iss-hololens/Library/com.unity.addressables/AddressablesBuildTEP.json
@@ -1,0 +1,9 @@
+{
+"Date": "12/05/2022 12:10:56",
+"UnityVersion": "2020.3.0f1",
+"com.unity.scriptablebuildpipeline": "1.15.2",
+"com.unity.addressables": "1.16.19",
+"traceEvents": [
+{"name": "Building Use Asset Database (fastest)", "ph": "X", "dur": 2122.7, "tid": 1, "ts": 7360, "pid": 1}
+]
+}

--- a/ISS/iss-hololens/ProjectSettings/EditorBuildSettings.asset
+++ b/ISS/iss-hololens/ProjectSettings/EditorBuildSettings.asset
@@ -5,24 +5,6 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
-    path: Assets/Scenes/MainScene.unity
-    guid: 9fc0d4010bbf28b4594072e72b8655ab
-  - enabled: 0
-    path: Assets/Scenes/Supporting Scenes/ModuleStartScenes/1_Build3DScene.unity
-    guid: 9a7d550ad40e8664c998a0d8188983d1
-  - enabled: 0
-    path: Assets/Scenes/Supporting Scenes/ModuleStartScenes/2_PlaceDigitalTwinAssets.unity
-    guid: 54688889886f6174a98ccbd5c6d644e0
-  - enabled: 0
-    path: Assets/Scenes/Supporting Scenes/ModuleStartScenes/3_ConnectToTwinData.unity
-    guid: d4a92f002db28294caf0aeefcdce0cba
-  - enabled: 0
-    path: Assets/Scenes/Supporting Scenes/ModuleStartScenes/4_OperateWindFarm.unity
-    guid: 5273acd75b06f254893edca571bd6935
-  - enabled: 0
-    path: Assets/Scenes/Supporting Scenes/ModuleStartScenes/Final_CompletedScene.unity
-    guid: 34300c868fed7a443b2203d70a848b30
   - enabled: 1
     path: Assets/Scenes/MainScene.unity
     guid: 9b525369e7b672e44b91a2da80a9fa11

--- a/ISS/iss-hololens/ProjectSettings/ProjectSettings.asset
+++ b/ISS/iss-hololens/ProjectSettings/ProjectSettings.asset
@@ -144,6 +144,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 5725833251393697937, guid: ba16014566e21274cb627786d3a825ab, type: 2}
   - {fileID: -1251499792108894643, guid: abff8632290b16d4a95422c2d70e39c1, type: 2}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/ISS/iss-hololens/UserSettings/EditorUserSettings.asset
+++ b/ISS/iss-hololens/UserSettings/EditorUserSettings.asset
@@ -24,16 +24,16 @@ EditorUserSettings:
       value: 22424703114646680e0b0227036c6c0506071738382128376d1a1e36ece52777d6e225fdd2130f3d3707e30b0d30050be7180b02f80e453f141de93b38cf111d14c92fcc14cc2b09d91b15c0c853c4eddcc2cd
       flags: 0
     RecentlyUsedScenePath-6:
-      value: 22424703114646680e0b0227036c72111f192b292926237e38271427fb
-      flags: 0
-    RecentlyUsedScenePath-7:
       value: 22424703114646680e0b0227036c6c0506071738382128376d1a1e36ece52777cfe832fceb3f0c283810fb0f073b0f3ae1452f02f80a06343201f01e1dfa041615f61bc014cd5109c51008d7
       flags: 0
-    RecentlyUsedScenePath-8:
+    RecentlyUsedScenePath-7:
       value: 22424703114646680e0b0227036c7c1f1b07142f382d22032e2c1336acf53a31f6fe
       flags: 0
-    RecentlyUsedScenePath-9:
+    RecentlyUsedScenePath-8:
       value: 224247031146467e0c1c182a5f065e02021f2b292926237e38271427fb
+      flags: 0
+    RecentlyUsedScenePath-9:
+      value: 22424703114646680e0b0227036c72111f192b292926237e38271427fb
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
## Purpose
Unity .meta files required for using the Hololens project were previously excluded. Without these, the project can be opened but asset and script references are broken.
This PR restores those files, resolving the issue.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Unity project asset references are intact.
* Objects in existing scenes appear normal, and not bright pink
* Scene hierarchy shows prefabs normally, not "(Missing Prefab)"